### PR TITLE
Update references to the new github organization eclipse-cdt-cloud instead of theia-ide

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Swagger has recently been added to the Trace Compass trace-server (reference imp
 [swagger]: https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-configuration#openapiresource
 [tcServer]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/
 [tracecompass]: https://projects.eclipse.org/projects/tools.tracecompass/developer
-[tspClient]: https://github.com/theia-ide/tsp-typescript-client
-[tspGhPages]: https://theia-ide.github.io/trace-server-protocol/
+[tspClient]: https://github.com/eclipse-cdt-cloud/tsp-typescript-client
+[tspGhPages]: https://eclipse-cdt-cloud.github.io/trace-server-protocol/
 [vscodeOpenapi]: https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Swagger has recently been added to the Trace Compass trace-server (reference imp
 1. Make sure to transfer the diffs to `API-proposed.yaml` as well.
 1. `openapi.yaml` should not be merged to the repository and can be deleted when not needed anymore.
 
-[apiProposed]: https://theia-ide.github.io/trace-server-protocol/proposed/
+[apiProposed]: https://eclipse-cdt-cloud.github.io/trace-server-protocol/proposed/
 [apiyaml]: http://localhost:8080/tsp/api/openapi.yaml
 [incubator]: https://projects.eclipse.org/projects/tools.tracecompass.incubator/developer
 [swagger]: https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-configuration#openapiresource


### PR DESCRIPTION
This PR updates all references to the new github organization eclipse-cdt-cloud instead of theia-ide. This includes gh-pages and other relevant repositories. 

Please note that the update of gh-pages references is necessary, because the old link is not redirected. For other links, there is an automatic redirection in place, but nonetheless, this PR updates the links to the new location.

