### PR TITLE
Add contribution documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Trace Server Protocol
+
+Thanks for your interest in the [Trace Server Protocol][protocol]!
+The following is a set of guidelines for contributing to the protocol.
+
+## How to Contribute
+
+In order to contribute, please first [open an issue][issues] that clearly describes the bug you
+intend to fix or the feature you would like to add. Make sure you provide a way to reproduce
+the bug or test the proposed feature.
+
+Once you have your code ready for review, please open a [pull request][pr].
+
+A committer will then review your contribution and help to get it merged.
+
+## Code of Conduct
+
+This project is governed by the [Eclipse Community Code of Conduct][conduct].
+By participating, you are expected to uphold this code.
+
+## Eclipse Development Process
+
+This Eclipse Foundation open project is governed by the [Eclipse Foundation
+Development Process][dev-process] and operates under the terms of the [Eclipse IP Policy][ip-policy].
+
+## Eclipse Contributor Agreement
+
+In order to be able to contribute to Eclipse Foundation projects you must
+electronically sign the [Eclipse Contributor Agreement (ECA)][eca].
+
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
+
+For more information, please see the [Eclipse Committer Handbook][handbook].
+
+## Contact
+
+For questions related to the Trace Server Protocol, please open a GitHub [issue tracker][issues].
+
+The Trace Server Protocol is part of `eclipse-cdt-cloud`. If you have any questions regarding CDT Cloud,
+please refer to the contact options listed on the [CDT.Cloud website][cdt].
+
+[cdt]: https://cdt-cloud.io/contact/
+[conduct]: https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md
+[dev-process]: https://eclipse.org/projects/dev_process
+[eca]: https://www.eclipse.org/legal/ECA.php
+[handbook]: https://www.eclipse.org/projects/handbook/#resources-commit
+[ip-policy]: https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+[issues]: https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues
+[pr]: https://github.com/eclipse-cdt-cloud/trace-server-protocol/pulls
+[protocol]: https://github.com/eclipse-cdt-cloud/trace-server-protocol

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The protocol is meant to be RESTful, over HTTP.
 
 The specification is currently written in **OpenAPI 3.0** and can be pretty-visualized in the [github pages][tspGhPages].
 
+**👋 Want to help?** Read our [contributor guide][contributing].
+
 ## Current version
 
 The current version of the specification is currently implemented and supported in the [Trace Compass trace-server][tcServer] (reference implementation) and what is currently supported by the [tsp-typescript-client][tspClient].
@@ -62,6 +64,7 @@ Swagger has recently been added to the Trace Compass trace-server (reference imp
 
 [apiProposed]: https://eclipse-cdt-cloud.github.io/trace-server-protocol/proposed/
 [apiyaml]: http://localhost:8080/tsp/api/openapi.yaml
+[contributing]: CONTRIBUTING.md
 [incubator]: https://projects.eclipse.org/projects/tools.tracecompass.incubator/developer
 [swagger]: https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-configuration#openapiresource
 [tcServer]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/


### PR DESCRIPTION
This commit adds CONTRIBUTING.md to inform contributors of important contribution policies, legal documents, agreements and guidelines.