### PR TITLE
API{-proposed}.yaml: Add XYModel series description

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2466,6 +2466,7 @@ components:
       properties:
         series:
           type: array
+          description: The collection of series
           items:
             $ref: '#/components/schemas/SeriesModel'
         title:

--- a/API.yaml
+++ b/API.yaml
@@ -1773,6 +1773,7 @@ components:
       properties:
         series:
           type: array
+          description: The collection of series
           items:
             $ref: '#/components/schemas/SeriesModel'
         title:


### PR DESCRIPTION
This change depends on (the reference) o.e.t.incubator trace-server
change [1], below. That change [1]'s commit message explains this fix.

[1] server: Add a description for getSeries in XYModel

Signed-off-by: Marco Miller <marco.miller@ericsson.com>