### PR TITLE
Add APIs for XY specific attributes for XY Entries

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Ericsson
+# Copyright (c) 2018, 2023 Ericsson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -2507,6 +2507,26 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/XYModel'
+    XYTreeEntry:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeDataModel'
+      - type: object
+        properties:
+          isDefault:
+            type: boolean
+            description: Optional flag to indicate whether or not the entry is a default
+              entry and its xy data should be fetched by default.
+    XYTreeEntryModel:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeEntryModel'
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/XYTreeEntry'
     XYTreeResponse:
       type: object
       allOf:
@@ -2514,7 +2534,7 @@ components:
       - type: object
         properties:
           model:
-            $ref: '#/components/schemas/TreeEntryModel'
+            $ref: '#/components/schemas/XYTreeEntryModel'
     Experiment:
       type: object
       properties:

--- a/API.yaml
+++ b/API.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Ericsson
+# Copyright (c) 2018, 2023 Ericsson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1814,6 +1814,26 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/XYModel'
+    XYTreeEntry:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeDataModel'
+      - type: object
+        properties:
+          isDefault:
+            type: boolean
+            description: Optional flag to indicate whether or not the entry is a default
+              entry and its xy data should be fetched by default.
+    XYTreeEntryModel:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeEntryModel'
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/XYTreeEntry'
     XYTreeResponse:
       type: object
       allOf:
@@ -1821,7 +1841,7 @@ components:
       - type: object
         properties:
           model:
-            $ref: '#/components/schemas/TreeEntryModel'
+            $ref: '#/components/schemas/XYTreeEntryModel'
     Experiment:
       type: object
       properties:


### PR DESCRIPTION
- Added XYTreeEntry: it extends TreeDataModel and adds XY specific attributes. Currently, the optional flag 'isDefault' is added to indicate that entry should be checked and its xy data should be drawn by default
- Added XYTreeEntryModel: it extends TreeEntryModel and returns a list of XYTreeEntry instead
- Updated XYTreeResponse: it returns a XYTreeEntryModel now

Contributes to https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/786
Trace Compass server swagger documentation: https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/199321/1

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>