### PR TITLE
Add schema to ConfigurationSourceType

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2168,25 +2168,36 @@ components:
           type: string
           description: Describes the configuration parameter
       description: A list of configuration parameter descriptors to be passed when
-        creating or updating a configuration instance of this type.
+        creating or updating a configuration instance of this type. Use this instead
+        of schema. Omit if not used.
     ConfigurationSourceType:
       type: object
       properties:
         parameterDescriptors:
           type: array
           description: A list of configuration parameter descriptors to be passed
-            when creating or updating a configuration instance of this type.
+            when creating or updating a configuration instance of this type. Use this
+            instead of schema. Omit if not used.
           items:
             $ref: '#/components/schemas/ConfigurationParameterDescriptor'
         description:
           type: string
           description: Describes the configuration source type
+        schema:
+          $ref: '#/components/schemas/OptionalSchema'
         name:
           type: string
           description: The human readable name
         id:
           type: string
           description: The unique ID of the configuration source type
+    OptionalSchema:
+      type: object
+      description: A JSON object that describes a JSON schema for parameters that
+        the front-end needs to provide with corresponding values. The schema has to
+        adhere to JSON schema specification (see https://json-schema.org/). Use this
+        for complex parameter descriptions instead of parameterDescriptors. Omit if
+        not used.
     ConfigurationQueryParameters:
       required:
       - parameters

--- a/API.yaml
+++ b/API.yaml
@@ -1475,25 +1475,36 @@ components:
           type: string
           description: Describes the configuration parameter
       description: A list of configuration parameter descriptors to be passed when
-        creating or updating a configuration instance of this type.
+        creating or updating a configuration instance of this type. Use this instead
+        of schema. Omit if not used.
     ConfigurationSourceType:
       type: object
       properties:
         parameterDescriptors:
           type: array
           description: A list of configuration parameter descriptors to be passed
-            when creating or updating a configuration instance of this type.
+            when creating or updating a configuration instance of this type. Use this
+            instead of schema. Omit if not used.
           items:
             $ref: '#/components/schemas/ConfigurationParameterDescriptor'
         description:
           type: string
           description: Describes the configuration source type
+        schema:
+          $ref: '#/components/schemas/OptionalSchema'
         name:
           type: string
           description: The human readable name
         id:
           type: string
           description: The unique ID of the configuration source type
+    OptionalSchema:
+      type: object
+      description: A JSON object that describes a JSON schema for parameters that
+        the front-end needs to provide with corresponding values. The schema has to
+        adhere to JSON schema specification (see https://json-schema.org/). Use this
+        for complex parameter descriptions instead of parameterDescriptors. Omit if
+        not used.
     ConfigurationQueryParameters:
       required:
       - parameters


### PR DESCRIPTION
API.yaml updates to add schema field to ConfigurationSourceType data structure to support [json-schemas](https://json-schema.org/).

Generated with Trace Compass server swagger update which is part of:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/66

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>