### PR TITLE
Add the parameter "properties" to Trace

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -55,16 +55,6 @@ tags:
   description: Query virtual table models (e.g. Events Table).
 - name: XY
   description: Query XY chart models.
-- name: Bookmarks
-  description: How to bookmark areas of interest in the trace.
-- name: Data Tree
-  description: Learn about querying generic data tree models.
-- name: Filters
-  description: How to filter and query.
-- name: Features
-  description: Discover the features which are available on a given server.
-- name: Symbols
-  description: Learn how to provide symbol providers.
 paths:
   /config/types/{typeId}/configs/{configId}:
     get:
@@ -1225,65 +1215,6 @@ paths:
             application/json:
               schema:
                 type: string
-    put:
-      summary: Update an experiment's content and name.
-      operationId: putExperiment
-      tags:
-        - Experiments
-      parameters:
-        - name: expUUID
-          in: path
-          description: UUID of the experiment to modify
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: name
-          in: query
-          description: The name to give this experiment
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: Additional information to update an experiment
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                expTypeID:
-                  description: Type ID to apply to this experiment
-                  type: string
-                traces:
-                  description: Traces to modify in this experiment
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      traceUUID:
-                        description: The unique identifier of the trace
-                        type: string
-                        format: uuid
-                      timeOffset:
-                        description: Time offset to apply to this trace
-                        type: integer
-                        format: int64
-                      action:
-                        description: Action to perform on the given trace (add or remove from the experiment)
-                        type: string
-                        enum: [add, remove]
-                        default: add
-                    required:
-                      - traceUUID
-                      - action
-      responses:
-        200:
-          description: The Experiment was successfully modified
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Experiment"
   /experiments:
     get:
       tags:
@@ -1502,630 +1433,6 @@ paths:
             application/json:
               schema:
                 type: string
-  /about/traceTypes:
-    get:
-      summary: Get the list of trace types supported by this server.
-      operationId: getTraceTypes
-      tags:
-        - Features
-      responses:
-        200:
-          description: List of the trace types supported by this server.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    ID:
-                      description: The unique identifier for this trace type
-                      type: string
-                    description:
-                      description: Human readable description of this trace type
-                      type: string
-                    versions:
-                      description: List supported versions
-                      type: array
-                      items:
-                        type: string
-  /about/outputTypes:
-    get:
-      summary: Get the list of outputs supported by this server.
-      tags:
-        - Features
-      responses:
-        200:
-          description: List of the output types supported by this server.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    ID:
-                      description: The unique identifier for this output provider type
-                      type: string
-                    description:
-                      description: Human readable description of this output type
-                      type: string
-                    versions:
-                      description: List supported versions
-                      type: array
-                      items:
-                        type: string
-  /filters:
-    get:
-      summary: Get the list of filters available.
-      operationId: getFilters
-      tags:
-        - Filters
-      responses:
-        200:
-          description: List of filters available.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Filter"
-    post:
-      summary: Create a new filter.
-      operationId: addFilter
-      tags:
-        - Filters
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  description: Human readable label for this filter
-                  type: string
-                start:
-                  description: start time for this filter
-                  type: integer
-                  format: int64
-                end:
-                  description: end time for this filter
-                  type: integer
-                  format: int64
-                filterExpression:
-                  description: expression from the filter language
-                  type: string
-                tags:
-                  description: Desired tags to apply when an elements pass the filter
-                  type: integer
-                  format: int32
-              required:
-                - start
-                - end
-                - filterExpression
-      responses:
-        200:
-          description: Created filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Filter"
-  /filters/{filterID}:
-    get:
-      summary: Get the filter with the given ID.
-      operationId: getFilter
-      tags:
-        - Filters
-      parameters:
-        - name: filterID
-          description: Filter ID
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int32
-      responses:
-        200:
-          description: The filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Filter"
-    put:
-      summary: Update the given filter.
-      operationId: updateFilter
-      tags:
-        - Filters
-      parameters:
-        - name: filterID
-          description: Filter ID
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int32
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  description: Human readable label for this filter
-                  type: string
-                start:
-                  description: start time for this filter
-                  type: integer
-                  format: int64
-                end:
-                  description: end time for this filter
-                  type: integer
-                  format: int64
-                filterExpression:
-                  description: expression from the filter language
-                  type: string
-                tags:
-                  description: Desired tags to apply when an elements pass the filter
-                  type: integer
-                  format: int32
-      responses:
-        200:
-          description: The filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Filter"
-    delete:
-      summary: Delete the given filter
-      operationId: deleteFilter
-      tags:
-        - Filters
-      parameters:
-        - name: filterID
-          description: Filter ID
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int32
-      responses:
-        200:
-          description: The deleted filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Filter"
-        204:
-          description: There was no filter with this ID to delete
-  /symbols/{hostID}/{PID}:
-    post:
-      tags:
-        - Symbols
-      summary: Import/Upload a symbol provider.
-      operationId: addSymbolProvider
-      parameters:
-        - name: hostID
-          in: path
-          description: Host ID for the symbol provider
-          required: true
-          schema:
-            type: string
-        - name: PID
-          in: path
-          description: PID for the symbol provider
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: URL to the symbol provider, not required if the symbol provider is uploaded directly to the endpoint.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                url:
-                  description: URL to the symbol provider, not required if the symbol provider is uploaded directly to the endpoint.
-                  type: string
-      responses:
-        200:
-          description: The symbol provider has been successfully added to the trace server.
-        406:
-          description: "Not acceptable: cannot read this symbol provider type"
-    get:
-      tags:
-        - Symbols
-      summary: Gets the symbol providers
-      operationId: getSymbols
-      parameters:
-        - name: hostID
-          in: path
-          description: The host's ID
-          required: true
-          schema:
-            type: string
-        - name: PID
-          in: path
-          description: Process ID
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Returns the Symbol providers for this query.
-        404:
-          description: No such Host, Thread and address combination.
-  /experiments/{expUUID}/bookmarks:
-    get:
-      summary: Get the collection of bookmarks for an experiment.
-      operationId: getExperimentBookmarks
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns a list of bookmarks for this trace
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such experiment
-          content:
-            application/json:
-              schema:
-                type: string
-    post:
-      summary: Add a bookmark to an experiment.
-      operationId: postExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        description: The bookmark to post
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Bookmark"
-      responses:
-        200:
-          description: Returns the bookmark's Id
-          content:
-            application/json:
-              schema:
-                type: integer
-        404:
-          description: No such trace
-          content:
-            application/json:
-              schema:
-                type: string
-  /experiments/{expUUID}/bookmarks/{bookmarkId}:
-    get:
-      summary: Get a specific bookmark from this experiment
-      operationId: getExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to get
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns the queried bookmark
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such experiment / No such bookmark
-          content:
-            application/json:
-              schema:
-                type: string
-    put:
-      summary: Modify a bookmark
-      operationId: putExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to modify
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: The bookmark to update
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Bookmark"
-      responses:
-        200:
-          description: Returns the bookmark's Id
-          content:
-            application/json:
-              schema:
-                type: integer
-        404:
-          description: No such trace
-          content:
-            application/json:
-              schema:
-                type: string
-    delete:
-      summary: Delete a bookmark
-      operationId: deleteExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to delete
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns the deleted bookmark
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such trace or bookmark
-          content:
-            application/json:
-              schema:
-                type: string
-  /experiments/{expUUID}/outputs/data/{outputID}/tree:
-    post:
-      tags:
-        - Data Tree
-      summary: API to get a data tree.
-      description: Unique entry point for output providers,
-        to get the tree of visible entries
-      operationId: getDataTreeEntry
-      parameters:
-        - name: expUUID
-          in: path
-          description: UUID of the experiment to query
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: outputID
-          in: path
-          description: ID of the output provider to query
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: Query parameters to fetch the data tree.
-          When 'requested_times' is absent the tree for the full range is returned. When present it specifies a range as [start, end].
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                parameters:
-                  type: object
-                  properties:
-                    requested_times:
-                      type: array
-                      items:
-                        type: integer
-                  additionalProperties:
-                    type: object
-              required:
-                - parameters
-              example:
-                parameters:
-                  requested_times: [111111111, 222222222]
-      responses:
-        200:
-          description: Returns a list of data tree entries. The returned model must be consistent, parentIds must refer to a parent which exists in the model.
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/GenericResponse"
-                  - type: object
-                    properties:
-                      model:
-                        $ref: "#/components/schemas/TreeEntryModel"
-        404:
-          description: Experiment or output provider not found
-          content:
-            application/json:
-              schema:
-                type: string
-  /experiments/{expUUID}/outputs/XY/{outputID}/tooltip:
-    get:
-      tags:
-        - XY
-      summary: API to get the XY tooltips.
-      description: Endpoint to retrieve tooltips for XY
-      operationId: getXYTooltip
-      parameters:
-        - name: expUUID
-          in: path
-          description: UUID of the experiment to query
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: outputID
-          in: path
-          description: ID of the output provider to query
-          required: true
-          schema:
-            type: string
-        - name: xValue
-          in: query
-          description: The xValue for which to get the tooltip
-          required: true
-          schema:
-            type: integer
-        - name: yValue
-          in: query
-          description: The yValue for which to get the tooltip
-          schema:
-            type: number
-        - name: entryId
-          in: query
-          description: The entryId or seriesId for which to get the tooltip
-          schema:
-            type: integer
-      responses:
-        200:
-          description: Returns a list of tooltip keys to values
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    value:
-                      type: string
-        404:
-          description: Experiment or output provider not found
-          content:
-            application/json:
-              schema:
-                type: string
-  /experiments/{expUUID}/outputs/timeGraph/{outputID}/navigate/states:
-    post:
-      tags:
-        - TimeGraph
-      summary: Tentative API for TimeGraph navigation
-      operationId: navigateStates
-      description: Endpoint to retrieve the next / previous corresponding states
-      parameters:
-        - name: expUUID
-          in: path
-          description: UUID of the experiment to query
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: outputID
-          in: path
-          description: ID of the output provider to query
-          required: true
-          schema:
-            type: string
-        - name: direction
-          in: query
-          description: Direction of the navigation
-          required: true
-          schema:
-            type: string
-            enum: [next, previous]
-      requestBody:
-        description:
-          Query parameters to fetch the next / previous timegraph state.
-          The 'requested_times' array contains the currently selected time.
-          The 'requested_times' array contains the currently selected entryId.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                parameters:
-                  type: object
-                  properties:
-                    requested_times:
-                      type: array
-                      items:
-                        type: integer
-                    requested_items:
-                      type: array
-                      items:
-                        type: integer
-                  required:
-                    - requested_times
-                    - requested_items
-                  additionalProperties:
-                    type: object
-              required:
-                - parameters
-              example:
-                parameters:
-                  requested_times: [111111111]
-                  requested_items: [1]
-      responses:
-        200:
-          description: Returns a list of time graph row
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/GenericResponse"
-                  - type: object
-                    properties:
-                      desiredTime:
-                        type: integer
-                        format: int64
-                      desiredEntry:
-                        type: integer
-                        format: int64
-                      model:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/TimeGraphModel"
 components:
   schemas:
     Configuration:
@@ -2240,20 +1547,6 @@ components:
       - type
       type: object
       properties:
-        type:
-          type: string
-          description: Type of annotation indicating its location
-          enum:
-          - CHART
-          - TREE
-        time:
-          type: integer
-          description: Time of this annotation
-          format: int64
-        duration:
-          type: integer
-          description: Duration of this annotation
-          format: int64
         style:
           $ref: '#/components/schemas/OutputElementStyle'
         entryId:
@@ -2264,6 +1557,20 @@ components:
         label:
           type: string
           description: Text label of this annotation
+        time:
+          type: integer
+          description: Time of this annotation
+          format: int64
+        duration:
+          type: integer
+          description: Duration of this annotation
+          format: int64
+        type:
+          type: string
+          description: Type of annotation indicating its location
+          enum:
+          - CHART
+          - TREE
       description: An annotation is used to mark an interesting area at a given time
         or time range
     AnnotationModel:
@@ -2315,17 +1622,17 @@ components:
       properties:
         requested_timerange:
           $ref: '#/components/schemas/TimeRange'
+        requested_marker_categories:
+          type: array
+          items:
+            type: string
+        requested_marker_set:
+          type: string
         requested_items:
           type: array
           items:
             type: integer
             format: int32
-        requested_marker_set:
-          type: string
-        requested_marker_categories:
-          type: array
-          items:
-            type: string
     AnnotationsQueryParameters:
       required:
       - parameters
@@ -2339,15 +1646,15 @@ components:
       - start
       type: object
       properties:
+        start:
+          type: integer
+          description: The start of the time range
+          format: int64
         nbTimes:
           type: integer
           description: The number of timestamps to be sampled (1-65536) in the given
             range
           format: int32
-        start:
-          type: integer
-          description: The start of the time range
-          format: int64
         end:
           type: integer
           description: The end of the time range
@@ -2361,10 +1668,6 @@ components:
       - targetId
       type: object
       properties:
-        targetId:
-          type: integer
-          description: Target entry's unique ID
-          format: int64
         start:
           type: integer
           description: Start time for this arrow
@@ -2374,6 +1677,10 @@ components:
         sourceId:
           type: integer
           description: Source entry's unique ID
+          format: int64
+        targetId:
+          type: integer
+          description: Target entry's unique ID
           format: int64
         end:
           type: integer
@@ -2406,6 +1713,9 @@ components:
     TableColumnHeader:
       type: object
       properties:
+        description:
+          type: string
+          description: Description of the column
         name:
           type: string
           description: Displayed name for this column
@@ -2416,9 +1726,6 @@ components:
         type:
           type: string
           description: Type of data associated to this column
-        description:
-          type: string
-          description: Description of the column
     TableColumnHeadersResponse:
       type: object
       allOf:
@@ -2438,24 +1745,133 @@ components:
       properties:
         parameters:
           $ref: '#/components/schemas/OptionalParameters'
+    TreeColumnHeader:
+      required:
+      - name
+      type: object
+      properties:
+        dataType:
+          type: string
+          description: "Data type of column. Optional, data type STRING is applied\
+            \ if absent."
+          enum:
+          - NUMBER
+          - BINARY_NUMBER
+          - TIMESTAMP
+          - DURATION
+          - STRING
+          - TIME_RANGE
+        tooltip:
+          type: string
+          description: "Displayed tooltip for this header. Optional, no tooltip is\
+            \ applied if absent."
+        name:
+          type: string
+          description: Displayed name for this header
+    TreeDataModel:
+      required:
+      - id
+      - labels
+      type: object
+      properties:
+        style:
+          $ref: '#/components/schemas/OutputElementStyle'
+        parentId:
+          type: integer
+          description: "Unique id to identify this parent's entry, optional if this\
+            \ entry does not have a parent."
+          format: int64
+        hasData:
+          type: boolean
+          description: Whether or not this entry has data
+        labels:
+          type: array
+          description: Array of cell labels to be displayed. The length of the array
+            and the index of each column need to correspond to the header array returned
+            in the tree model.
+          items:
+            type: string
+        id:
+          type: integer
+          description: Unique id to identify this entry in the backend
+          format: int64
+      description: Base entry returned by tree endpoints
+    TreeEntryModel:
+      required:
+      - entries
+      type: object
+      properties:
+        headers:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeColumnHeader'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeDataModel'
+    XYTreeEntry:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeDataModel'
+      - type: object
+        properties:
+          isDefault:
+            type: boolean
+            description: Optional flag to indicate whether or not the entry is a default
+              entry and its xy data should be fetched by default.
+    XYTreeEntryModel:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeEntryModel'
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/XYTreeEntry'
+    XYTreeResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/GenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/XYTreeEntryModel'
+    TreeParameters:
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+    TreeQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/TreeParameters'
     VirtualTableCell:
       type: object
       properties:
-        content:
-          type: string
-          description: Content of the cell for this line
         tags:
           type: integer
           description: Specific tags for this cell. A value of 0 should be handled
             as none (no tags)
           format: int32
+        content:
+          type: string
+          description: Content of the cell for this line
     VirtualTableLine:
       type: object
       properties:
-        index:
-          type: integer
-          description: The index of this line in the virtual table
-          format: int64
+        cells:
+          type: array
+          description: The content of the cells for this line. This array matches
+            the column ids returned above
+          items:
+            $ref: '#/components/schemas/VirtualTableCell'
         tags:
           type: integer
           description: "Tags for the entire line. A bit mask to apply for tagging\
@@ -2463,19 +1879,20 @@ components:
             \ to indicate if a filter matches and what action to apply. Use 0 for\
             \ no tags, 1 and 2 are reserved, 4 for 'BORDER' and 8 for 'HIGHLIGHT'."
           format: int32
-        cells:
-          type: array
-          description: The content of the cells for this line. This array matches
-            the column ids returned above
-          items:
-            $ref: '#/components/schemas/VirtualTableCell'
+        index:
+          type: integer
+          description: The index of this line in the virtual table
+          format: int64
     VirtualTableModel:
       type: object
       properties:
-        size:
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/VirtualTableLine'
+        lowIndex:
           type: integer
-          description: "Number of events. If filtered, the size will be the number\
-            \ of events that match the filters"
+          description: Index in the virtual table of the first returned event
           format: int64
         columnIds:
           type: array
@@ -2484,14 +1901,11 @@ components:
           items:
             type: integer
             format: int64
-        lowIndex:
+        size:
           type: integer
-          description: Index in the virtual table of the first returned event
+          description: "Number of events. If filtered, the size will be the number\
+            \ of events that match the filters"
           format: int64
-        lines:
-          type: array
-          items:
-            $ref: '#/components/schemas/VirtualTableLine'
     VirtualTableResponse:
       type: object
       allOf:
@@ -2562,6 +1976,9 @@ components:
     DataProvider:
       type: object
       properties:
+        description:
+          type: string
+          description: Describes the output provider's features
         name:
           type: string
           description: The human readable name
@@ -2581,9 +1998,6 @@ components:
           - TREE_TIME_XY
           - TIME_GRAPH
           - DATA_TREE
-        description:
-          type: string
-          description: Describes the output provider's features
     TimeGraphModel:
       type: object
       properties:
@@ -2613,11 +2027,6 @@ components:
       - start
       type: object
       properties:
-        tags:
-          type: integer
-          description: Tags to apply on this state. A value of 0 should be handled
-            as none (no tags)
-          format: int32
         start:
           type: integer
           description: Start time for this state
@@ -2628,6 +2037,11 @@ components:
           type: string
           description: "Text label to apply to this TimeGraphState if resolution permits.\
             \ Optional, no label is applied if absent"
+        tags:
+          type: integer
+          description: Tags to apply on this state. A value of 0 should be handled
+            as none (no tags)
+          format: int32
         end:
           type: integer
           description: End time for this state
@@ -2645,6 +2059,13 @@ components:
       - filter_expressions_map
       type: object
       properties:
+        strategy:
+          type: string
+          description: Optional parameter that enables the full search (deep search)
+            or not
+          enum:
+          - SAMPLED
+          - DEEP
         filter_expressions_map:
           type: object
           additionalProperties:
@@ -2660,13 +2081,6 @@ components:
           description: "The key of this map can be \"1\" (means DIMMED) or \"4\" (means\
             \ EXCLUDED) and the value is an array of the desired search query (e.g.\
             \ {\"1\": [\"openat\", \"duration>10ms\"]})"
-        strategy:
-          type: string
-          description: Optional parameter that enables the full search (deep search)
-            or not
-          enum:
-          - SAMPLED
-          - DEEP
       description: FilterQueryParameters is used to support search and filter expressions
         for timegraph views
     RequestedParameters:
@@ -2732,6 +2146,14 @@ components:
       - time
       type: object
       properties:
+        destinationId:
+          type: integer
+          description: Destination entry's unique ID (arrow)
+          format: int64
+        entryId:
+          type: integer
+          description: "Entry's unique ID (annotation, arrow)"
+          format: int64
         time:
           type: integer
           description: Element's start time
@@ -2747,14 +2169,6 @@ components:
           type: integer
           description: Element's duration
           format: int64
-        entryId:
-          type: integer
-          description: "Entry's unique ID (annotation, arrow)"
-          format: int64
-        destinationId:
-          type: integer
-          description: Destination entry's unique ID (arrow)
-          format: int64
       description: An element model to be identified
     TooltipParameters:
       required:
@@ -2763,18 +2177,18 @@ components:
       - requested_times
       type: object
       properties:
-        requested_element:
-          $ref: '#/components/schemas/Element'
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
         requested_items:
           type: array
           items:
             type: integer
             format: int32
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+        requested_element:
+          $ref: '#/components/schemas/Element'
     TooltipQueryParameters:
       required:
       - parameters
@@ -2788,28 +2202,28 @@ components:
       - $ref: '#/components/schemas/TreeDataModel'
       - type: object
         properties:
-          start:
-            type: integer
-            description: Beginning of the range for which this entry exists
-            format: int64
           metadata:
             type: object
             additionalProperties:
               type: array
-              description: Optional metadata map for domain specific data for matching data
-                across data providers. Keys for the same data shall be the same across
-                data providers. Only values of type Number or String are allowed.
+              description: Optional metadata map for domain specific data for matching
+                data across data providers. Keys for the same data shall be the same
+                across data providers. Only values of type Number or String are allowed.
                 For each key all values shall have the same type.
               items:
                 type: object
-                description: Optional metadata map for domain specific data for matching data
-                  across data providers. Keys for the same data shall be the same
-                  across data providers. Only values of type Number or String are
-                  allowed. For each key all values shall have the same type.
-            description: Optional metadata map for domain specific data for matching data across
-              data providers. Keys for the same data shall be the same across data
-              providers. Only values of type Number or String are allowed. For each
-              key all values shall have the same type.
+                description: Optional metadata map for domain specific data for matching
+                  data across data providers. Keys for the same data shall be the
+                  same across data providers. Only values of type Number or String
+                  are allowed. For each key all values shall have the same type.
+            description: Optional metadata map for domain specific data for matching
+              data across data providers. Keys for the same data shall be the same
+              across data providers. Only values of type Number or String are allowed.
+              For each key all values shall have the same type.
+          start:
+            type: integer
+            description: Beginning of the range for which this entry exists
+            format: int64
           end:
             type: integer
             description: End of the range for which this entry exists
@@ -2832,85 +2246,6 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/TimeGraphTreeModel'
-    TreeColumnHeader:
-      required:
-      - name
-      type: object
-      properties:
-        name:
-          type: string
-          description: Displayed name for this header
-        dataType:
-          type: string
-          description: "Data type of column. Optional, data type STRING is applied\
-            \ if absent."
-          enum:
-          - NUMBER
-          - BINARY_NUMBER
-          - TIMESTAMP
-          - DURATION
-          - STRING
-          - TIME_RANGE
-        tooltip:
-          type: string
-          description: "Displayed tooltip for this header. Optional, no tooltip is\
-            \ applied if absent."
-    TreeDataModel:
-      required:
-      - id
-      - labels
-      type: object
-      properties:
-        id:
-          type: integer
-          description: Unique id to identify this entry in the backend
-          format: int64
-        hasData:
-          type: boolean
-          description: Whether or not this entry has data
-        style:
-          $ref: '#/components/schemas/OutputElementStyle'
-        parentId:
-          type: integer
-          description: "Unique id to identify this parent's entry, optional if this\
-            \ entry does not have a parent."
-          format: int64
-        labels:
-          type: array
-          description: Array of cell labels to be displayed. The length of the array
-            and the index of each column need to correspond to the header array returned
-            in the tree model.
-          items:
-            type: string
-      description: Base entry returned by tree endpoints
-    TreeEntryModel:
-      required:
-      - entries
-      type: object
-      properties:
-        entries:
-          type: array
-          items:
-            $ref: '#/components/schemas/TreeDataModel'
-        headers:
-          type: array
-          items:
-            $ref: '#/components/schemas/TreeColumnHeader'
-    TreeParameters:
-      type: object
-      properties:
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
-    TreeQueryParameters:
-      required:
-      - parameters
-      type: object
-      properties:
-        parameters:
-          $ref: '#/components/schemas/TreeParameters'
     SeriesModel:
       required:
       - seriesId
@@ -2920,6 +2255,8 @@ components:
       - yValues
       type: object
       properties:
+        style:
+          $ref: '#/components/schemas/OutputElementStyle'
         seriesId:
           type: integer
           description: Series' ID
@@ -2927,8 +2264,6 @@ components:
         seriesName:
           type: string
           description: Series' name
-        style:
-          $ref: '#/components/schemas/OutputElementStyle'
         xValues:
           type: array
           description: Series' X values
@@ -2964,40 +2299,9 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/XYModel'
-    XYTreeEntry:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/TreeDataModel'
-      - type: object
-        properties:
-          isDefault:
-            type: boolean
-            description: Optional flag to indicate whether or not the entry is a default
-              entry and its xy data should be fetched by default.
-    XYTreeEntryModel:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/TreeEntryModel'
-      - type: object
-        properties:
-          entries:
-            type: array
-            items:
-              $ref: '#/components/schemas/XYTreeEntry'
-    XYTreeResponse:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/GenericResponse'
-      - type: object
-        properties:
-          model:
-            $ref: '#/components/schemas/XYTreeEntryModel'
     Experiment:
       type: object
       properties:
-        name:
-          type: string
-          description: User defined name for the experiment
         traces:
           type: array
           description: The traces encapsulated by this experiment
@@ -3022,6 +2326,9 @@ components:
           type: integer
           description: The experiment's end time
           format: int64
+        name:
+          type: string
+          description: User defined name for the experiment
         UUID:
           type: string
           description: The experiment's unique identifier
@@ -3029,12 +2336,6 @@ components:
     Trace:
       type: object
       properties:
-        name:
-          type: string
-          description: User defined name for the trace
-        path:
-          type: string
-          description: Path to the trace on the server's file system
         nbEvents:
           type: integer
           description: Current number of indexed events in the trace
@@ -3054,6 +2355,18 @@ components:
           type: integer
           description: The trace's end time
           format: int64
+        name:
+          type: string
+          description: User defined name for the trace
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+            description: The trace's properties
+          description: The trace's properties
+        path:
+          type: string
+          description: Path to the trace on the server's file system
         UUID:
           type: string
           description: The trace's unique identifier
@@ -3064,9 +2377,6 @@ components:
       - traces
       type: object
       properties:
-        name:
-          type: string
-          description: The name to give this experiment
         traces:
           type: array
           description: The unique identifiers of the traces to encapsulate in this
@@ -3074,6 +2384,9 @@ components:
           items:
             type: string
             format: uuid
+        name:
+          type: string
+          description: The name to give this experiment
     ServerStatus:
       type: object
       properties:
@@ -3089,12 +2402,21 @@ components:
       - version
       type: object
       properties:
-        version:
+        productId:
           type: string
-          description: Version in the format Major.Minor.Micro
+          description: Product identifier for the trace server
         buildTime:
           type: string
           description: "Build time or qualifier of the server version, if available"
+        os:
+          type: string
+          description: Operating system name
+        osArch:
+          type: string
+          description: Architecture of the operating system
+        osVersion:
+          type: string
+          description: Operating system version
         cpuCount:
           type: integer
           description: Number of CPUs available
@@ -3106,81 +2428,23 @@ components:
         launcherName:
           type: string
           description: "Name of the launcher used, if available"
-        os:
+        version:
           type: string
-          description: Operating system name
-        osArch:
-          type: string
-          description: Architecture of the operating system
-        osVersion:
-          type: string
-          description: Operating system version
-        productId:
-          type: string
-          description: Product identifier for the trace server
+          description: Version in the format Major.Minor.Micro
       description: System Information Response
     TraceQueryParameters:
       required:
       - uri
       type: object
       properties:
-        name:
-          type: string
-          description: "The name of the trace in the server, to override the default\
-            \ name"
         typeID:
           type: string
           description: "The trace type's ID, to force the use of a parser / disambiguate\
             \ the trace type"
+        name:
+          type: string
+          description: "The name of the trace in the server, to override the default\
+            \ name"
         uri:
           type: string
           description: URI of the trace
-    Bookmark:
-      type: object
-      properties:
-        start:
-          description: the start time for this bookmark.
-          type: integer
-          format: int64
-        end:
-          description: the end time for this bookmark.
-          type: integer
-          format: int64
-        name:
-          description: this bookmark's name
-          type: string
-        type:
-          description: The type of the bookmark (generic, output, ...)
-          type: string
-        iconUrl:
-          description: URL to the bookmark's icon
-          type: string
-        UUID:
-          description: The bookmark's unique ID, generated by the server.
-          type: string
-          format: uuid
-    Filter:
-      type: object
-      properties:
-        id:
-          description: Unique id to identify this entry in the backend.
-          type: integer
-          format: int32
-        name:
-          description: Human readable label for this filter
-          type: string
-        start:
-          description: start time for this filter
-          type: integer
-          format: int64
-        end:
-          description: end time for this filter
-          type: integer
-          format: int64
-        expression:
-          description: expression from the filter language
-          type: string
-        tags:
-          description: Tags to be applied on elements that pass this filter
-          type: integer
-          format: int32

--- a/API.yaml
+++ b/API.yaml
@@ -1547,20 +1547,6 @@ components:
       - type
       type: object
       properties:
-        type:
-          type: string
-          description: Type of annotation indicating its location
-          enum:
-          - CHART
-          - TREE
-        time:
-          type: integer
-          description: Time of this annotation
-          format: int64
-        duration:
-          type: integer
-          description: Duration of this annotation
-          format: int64
         style:
           $ref: '#/components/schemas/OutputElementStyle'
         entryId:
@@ -1571,6 +1557,20 @@ components:
         label:
           type: string
           description: Text label of this annotation
+        time:
+          type: integer
+          description: Time of this annotation
+          format: int64
+        duration:
+          type: integer
+          description: Duration of this annotation
+          format: int64
+        type:
+          type: string
+          description: Type of annotation indicating its location
+          enum:
+          - CHART
+          - TREE
       description: An annotation is used to mark an interesting area at a given time
         or time range
     AnnotationModel:
@@ -1622,17 +1622,17 @@ components:
       properties:
         requested_timerange:
           $ref: '#/components/schemas/TimeRange'
+        requested_marker_categories:
+          type: array
+          items:
+            type: string
+        requested_marker_set:
+          type: string
         requested_items:
           type: array
           items:
             type: integer
             format: int32
-        requested_marker_set:
-          type: string
-        requested_marker_categories:
-          type: array
-          items:
-            type: string
     AnnotationsQueryParameters:
       required:
       - parameters
@@ -1646,15 +1646,15 @@ components:
       - start
       type: object
       properties:
+        start:
+          type: integer
+          description: The start of the time range
+          format: int64
         nbTimes:
           type: integer
           description: The number of timestamps to be sampled (1-65536) in the given
             range
           format: int32
-        start:
-          type: integer
-          description: The start of the time range
-          format: int64
         end:
           type: integer
           description: The end of the time range
@@ -1668,10 +1668,6 @@ components:
       - targetId
       type: object
       properties:
-        targetId:
-          type: integer
-          description: Target entry's unique ID
-          format: int64
         start:
           type: integer
           description: Start time for this arrow
@@ -1681,6 +1677,10 @@ components:
         sourceId:
           type: integer
           description: Source entry's unique ID
+          format: int64
+        targetId:
+          type: integer
+          description: Target entry's unique ID
           format: int64
         end:
           type: integer
@@ -1713,6 +1713,9 @@ components:
     TableColumnHeader:
       type: object
       properties:
+        description:
+          type: string
+          description: Description of the column
         name:
           type: string
           description: Displayed name for this column
@@ -1723,9 +1726,6 @@ components:
         type:
           type: string
           description: Type of data associated to this column
-        description:
-          type: string
-          description: Description of the column
     TableColumnHeadersResponse:
       type: object
       allOf:
@@ -1745,24 +1745,133 @@ components:
       properties:
         parameters:
           $ref: '#/components/schemas/OptionalParameters'
+    TreeColumnHeader:
+      required:
+      - name
+      type: object
+      properties:
+        dataType:
+          type: string
+          description: "Data type of column. Optional, data type STRING is applied\
+            \ if absent."
+          enum:
+          - NUMBER
+          - BINARY_NUMBER
+          - TIMESTAMP
+          - DURATION
+          - STRING
+          - TIME_RANGE
+        tooltip:
+          type: string
+          description: "Displayed tooltip for this header. Optional, no tooltip is\
+            \ applied if absent."
+        name:
+          type: string
+          description: Displayed name for this header
+    TreeDataModel:
+      required:
+      - id
+      - labels
+      type: object
+      properties:
+        style:
+          $ref: '#/components/schemas/OutputElementStyle'
+        parentId:
+          type: integer
+          description: "Unique id to identify this parent's entry, optional if this\
+            \ entry does not have a parent."
+          format: int64
+        hasData:
+          type: boolean
+          description: Whether or not this entry has data
+        labels:
+          type: array
+          description: Array of cell labels to be displayed. The length of the array
+            and the index of each column need to correspond to the header array returned
+            in the tree model.
+          items:
+            type: string
+        id:
+          type: integer
+          description: Unique id to identify this entry in the backend
+          format: int64
+      description: Base entry returned by tree endpoints
+    TreeEntryModel:
+      required:
+      - entries
+      type: object
+      properties:
+        headers:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeColumnHeader'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeDataModel'
+    XYTreeEntry:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeDataModel'
+      - type: object
+        properties:
+          isDefault:
+            type: boolean
+            description: Optional flag to indicate whether or not the entry is a default
+              entry and its xy data should be fetched by default.
+    XYTreeEntryModel:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/TreeEntryModel'
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/XYTreeEntry'
+    XYTreeResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/GenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/XYTreeEntryModel'
+    TreeParameters:
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+    TreeQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/TreeParameters'
     VirtualTableCell:
       type: object
       properties:
-        content:
-          type: string
-          description: Content of the cell for this line
         tags:
           type: integer
           description: Specific tags for this cell. A value of 0 should be handled
             as none (no tags)
           format: int32
+        content:
+          type: string
+          description: Content of the cell for this line
     VirtualTableLine:
       type: object
       properties:
-        index:
-          type: integer
-          description: The index of this line in the virtual table
-          format: int64
+        cells:
+          type: array
+          description: The content of the cells for this line. This array matches
+            the column ids returned above
+          items:
+            $ref: '#/components/schemas/VirtualTableCell'
         tags:
           type: integer
           description: "Tags for the entire line. A bit mask to apply for tagging\
@@ -1770,19 +1879,20 @@ components:
             \ to indicate if a filter matches and what action to apply. Use 0 for\
             \ no tags, 1 and 2 are reserved, 4 for 'BORDER' and 8 for 'HIGHLIGHT'."
           format: int32
-        cells:
-          type: array
-          description: The content of the cells for this line. This array matches
-            the column ids returned above
-          items:
-            $ref: '#/components/schemas/VirtualTableCell'
+        index:
+          type: integer
+          description: The index of this line in the virtual table
+          format: int64
     VirtualTableModel:
       type: object
       properties:
-        size:
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/VirtualTableLine'
+        lowIndex:
           type: integer
-          description: "Number of events. If filtered, the size will be the number\
-            \ of events that match the filters"
+          description: Index in the virtual table of the first returned event
           format: int64
         columnIds:
           type: array
@@ -1791,14 +1901,11 @@ components:
           items:
             type: integer
             format: int64
-        lowIndex:
+        size:
           type: integer
-          description: Index in the virtual table of the first returned event
+          description: "Number of events. If filtered, the size will be the number\
+            \ of events that match the filters"
           format: int64
-        lines:
-          type: array
-          items:
-            $ref: '#/components/schemas/VirtualTableLine'
     VirtualTableResponse:
       type: object
       allOf:
@@ -1869,6 +1976,9 @@ components:
     DataProvider:
       type: object
       properties:
+        description:
+          type: string
+          description: Describes the output provider's features
         name:
           type: string
           description: The human readable name
@@ -1888,9 +1998,6 @@ components:
           - TREE_TIME_XY
           - TIME_GRAPH
           - DATA_TREE
-        description:
-          type: string
-          description: Describes the output provider's features
     TimeGraphModel:
       type: object
       properties:
@@ -1920,11 +2027,6 @@ components:
       - start
       type: object
       properties:
-        tags:
-          type: integer
-          description: Tags to apply on this state. A value of 0 should be handled
-            as none (no tags)
-          format: int32
         start:
           type: integer
           description: Start time for this state
@@ -1935,6 +2037,11 @@ components:
           type: string
           description: "Text label to apply to this TimeGraphState if resolution permits.\
             \ Optional, no label is applied if absent"
+        tags:
+          type: integer
+          description: Tags to apply on this state. A value of 0 should be handled
+            as none (no tags)
+          format: int32
         end:
           type: integer
           description: End time for this state
@@ -1952,6 +2059,13 @@ components:
       - filter_expressions_map
       type: object
       properties:
+        strategy:
+          type: string
+          description: Optional parameter that enables the full search (deep search)
+            or not
+          enum:
+          - SAMPLED
+          - DEEP
         filter_expressions_map:
           type: object
           additionalProperties:
@@ -1967,13 +2081,6 @@ components:
           description: "The key of this map can be \"1\" (means DIMMED) or \"4\" (means\
             \ EXCLUDED) and the value is an array of the desired search query (e.g.\
             \ {\"1\": [\"openat\", \"duration>10ms\"]})"
-        strategy:
-          type: string
-          description: Optional parameter that enables the full search (deep search)
-            or not
-          enum:
-          - SAMPLED
-          - DEEP
       description: FilterQueryParameters is used to support search and filter expressions
         for timegraph views
     RequestedParameters:
@@ -2039,6 +2146,14 @@ components:
       - time
       type: object
       properties:
+        destinationId:
+          type: integer
+          description: Destination entry's unique ID (arrow)
+          format: int64
+        entryId:
+          type: integer
+          description: "Entry's unique ID (annotation, arrow)"
+          format: int64
         time:
           type: integer
           description: Element's start time
@@ -2054,14 +2169,6 @@ components:
           type: integer
           description: Element's duration
           format: int64
-        entryId:
-          type: integer
-          description: "Entry's unique ID (annotation, arrow)"
-          format: int64
-        destinationId:
-          type: integer
-          description: Destination entry's unique ID (arrow)
-          format: int64
       description: An element model to be identified
     TooltipParameters:
       required:
@@ -2070,18 +2177,18 @@ components:
       - requested_times
       type: object
       properties:
-        requested_element:
-          $ref: '#/components/schemas/Element'
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
         requested_items:
           type: array
           items:
             type: integer
             format: int32
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+        requested_element:
+          $ref: '#/components/schemas/Element'
     TooltipQueryParameters:
       required:
       - parameters
@@ -2095,28 +2202,28 @@ components:
       - $ref: '#/components/schemas/TreeDataModel'
       - type: object
         properties:
-          start:
-            type: integer
-            description: Beginning of the range for which this entry exists
-            format: int64
           metadata:
             type: object
             additionalProperties:
               type: array
-              description: Optional metadata map for domain specific data for matching data
-                across data providers. Keys for the same data shall be the same across
-                data providers. Only values of type Number or String are allowed.
+              description: Optional metadata map for domain specific data for matching
+                data across data providers. Keys for the same data shall be the same
+                across data providers. Only values of type Number or String are allowed.
                 For each key all values shall have the same type.
               items:
                 type: object
-                description: Optional metadata map for domain specific data for matching data
-                  across data providers. Keys for the same data shall be the same
-                  across data providers. Only values of type Number or String are
-                  allowed. For each key all values shall have the same type.
-            description: Optional metadata map for domain specific data for matching data across
-              data providers. Keys for the same data shall be the same across data
-              providers. Only values of type Number or String are allowed. For each
-              key all values shall have the same type.
+                description: Optional metadata map for domain specific data for matching
+                  data across data providers. Keys for the same data shall be the
+                  same across data providers. Only values of type Number or String
+                  are allowed. For each key all values shall have the same type.
+            description: Optional metadata map for domain specific data for matching
+              data across data providers. Keys for the same data shall be the same
+              across data providers. Only values of type Number or String are allowed.
+              For each key all values shall have the same type.
+          start:
+            type: integer
+            description: Beginning of the range for which this entry exists
+            format: int64
           end:
             type: integer
             description: End of the range for which this entry exists
@@ -2139,85 +2246,6 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/TimeGraphTreeModel'
-    TreeColumnHeader:
-      required:
-      - name
-      type: object
-      properties:
-        name:
-          type: string
-          description: Displayed name for this header
-        dataType:
-          type: string
-          description: "Data type of column. Optional, data type STRING is applied\
-            \ if absent."
-          enum:
-          - NUMBER
-          - BINARY_NUMBER
-          - TIMESTAMP
-          - DURATION
-          - STRING
-          - TIME_RANGE
-        tooltip:
-          type: string
-          description: "Displayed tooltip for this header. Optional, no tooltip is\
-            \ applied if absent."
-    TreeDataModel:
-      required:
-      - id
-      - labels
-      type: object
-      properties:
-        id:
-          type: integer
-          description: Unique id to identify this entry in the backend
-          format: int64
-        hasData:
-          type: boolean
-          description: Whether or not this entry has data
-        style:
-          $ref: '#/components/schemas/OutputElementStyle'
-        parentId:
-          type: integer
-          description: "Unique id to identify this parent's entry, optional if this\
-            \ entry does not have a parent."
-          format: int64
-        labels:
-          type: array
-          description: Array of cell labels to be displayed. The length of the array
-            and the index of each column need to correspond to the header array returned
-            in the tree model.
-          items:
-            type: string
-      description: Base entry returned by tree endpoints
-    TreeEntryModel:
-      required:
-      - entries
-      type: object
-      properties:
-        entries:
-          type: array
-          items:
-            $ref: '#/components/schemas/TreeDataModel'
-        headers:
-          type: array
-          items:
-            $ref: '#/components/schemas/TreeColumnHeader'
-    TreeParameters:
-      type: object
-      properties:
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
-    TreeQueryParameters:
-      required:
-      - parameters
-      type: object
-      properties:
-        parameters:
-          $ref: '#/components/schemas/TreeParameters'
     SeriesModel:
       required:
       - seriesId
@@ -2227,6 +2255,8 @@ components:
       - yValues
       type: object
       properties:
+        style:
+          $ref: '#/components/schemas/OutputElementStyle'
         seriesId:
           type: integer
           description: Series' ID
@@ -2234,8 +2264,6 @@ components:
         seriesName:
           type: string
           description: Series' name
-        style:
-          $ref: '#/components/schemas/OutputElementStyle'
         xValues:
           type: array
           description: Series' X values
@@ -2271,40 +2299,9 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/XYModel'
-    XYTreeEntry:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/TreeDataModel'
-      - type: object
-        properties:
-          isDefault:
-            type: boolean
-            description: Optional flag to indicate whether or not the entry is a default
-              entry and its xy data should be fetched by default.
-    XYTreeEntryModel:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/TreeEntryModel'
-      - type: object
-        properties:
-          entries:
-            type: array
-            items:
-              $ref: '#/components/schemas/XYTreeEntry'
-    XYTreeResponse:
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/GenericResponse'
-      - type: object
-        properties:
-          model:
-            $ref: '#/components/schemas/XYTreeEntryModel'
     Experiment:
       type: object
       properties:
-        name:
-          type: string
-          description: User defined name for the experiment
         traces:
           type: array
           description: The traces encapsulated by this experiment
@@ -2329,6 +2326,9 @@ components:
           type: integer
           description: The experiment's end time
           format: int64
+        name:
+          type: string
+          description: User defined name for the experiment
         UUID:
           type: string
           description: The experiment's unique identifier
@@ -2336,12 +2336,6 @@ components:
     Trace:
       type: object
       properties:
-        name:
-          type: string
-          description: User defined name for the trace
-        path:
-          type: string
-          description: Path to the trace on the server's file system
         nbEvents:
           type: integer
           description: Current number of indexed events in the trace
@@ -2361,6 +2355,18 @@ components:
           type: integer
           description: The trace's end time
           format: int64
+        name:
+          type: string
+          description: User defined name for the trace
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+            description: The trace's properties
+          description: The trace's properties
+        path:
+          type: string
+          description: Path to the trace on the server's file system
         UUID:
           type: string
           description: The trace's unique identifier
@@ -2371,9 +2377,6 @@ components:
       - traces
       type: object
       properties:
-        name:
-          type: string
-          description: The name to give this experiment
         traces:
           type: array
           description: The unique identifiers of the traces to encapsulate in this
@@ -2381,6 +2384,9 @@ components:
           items:
             type: string
             format: uuid
+        name:
+          type: string
+          description: The name to give this experiment
     ServerStatus:
       type: object
       properties:
@@ -2396,12 +2402,21 @@ components:
       - version
       type: object
       properties:
-        version:
+        productId:
           type: string
-          description: Version in the format Major.Minor.Micro
+          description: Product identifier for the trace server
         buildTime:
           type: string
           description: "Build time or qualifier of the server version, if available"
+        os:
+          type: string
+          description: Operating system name
+        osArch:
+          type: string
+          description: Architecture of the operating system
+        osVersion:
+          type: string
+          description: Operating system version
         cpuCount:
           type: integer
           description: Number of CPUs available
@@ -2413,32 +2428,23 @@ components:
         launcherName:
           type: string
           description: "Name of the launcher used, if available"
-        os:
+        version:
           type: string
-          description: Operating system name
-        osArch:
-          type: string
-          description: Architecture of the operating system
-        osVersion:
-          type: string
-          description: Operating system version
-        productId:
-          type: string
-          description: Product identifier for the trace server
+          description: Version in the format Major.Minor.Micro
       description: System Information Response
     TraceQueryParameters:
       required:
       - uri
       type: object
       properties:
-        name:
-          type: string
-          description: "The name of the trace in the server, to override the default\
-            \ name"
         typeID:
           type: string
           description: "The trace type's ID, to force the use of a parser / disambiguate\
             \ the trace type"
+        name:
+          type: string
+          description: "The name of the trace in the server, to override the default\
+            \ name"
         uri:
           type: string
           description: URI of the trace


### PR DESCRIPTION
Add the parameter "properties" introduced by commit 499408e3979cab403a5d58 in the server (incubator).

Link to the PR for the commit: [eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator#79](https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/79)

Part added:
```
        properties:
          type: object
          additionalProperties:
            type: string
            description: The trace's properties
          description: The trace's properties
```