### PR TITLE
Align OutputConfigurationQuery/Configuration for sourceTypeId

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2449,9 +2449,9 @@ components:
       - $ref: '#/components/schemas/ConfigurationQueryParameters'
       - type: object
         properties:
-          typeId:
+          sourceTypeId:
             type: string
-            description: TypeId of the configuration according to the corresponding
+            description: The type ID of the corresponding ConfigurationSourceType defined by this output.
               ConfigurationTypeDescriptor.
     AnnotationCategoriesModel:
       type: object

--- a/API.yaml
+++ b/API.yaml
@@ -1758,9 +1758,9 @@ components:
       - $ref: '#/components/schemas/ConfigurationQueryParameters'
       - type: object
         properties:
-          typeId:
+          sourceTypeId:
             type: string
-            description: TypeId of the configuration according to the corresponding
+            description: The type ID of the corresponding ConfigurationSourceType defined by this output.
               ConfigurationTypeDescriptor.
     AnnotationCategoriesModel:
       type: object


### PR DESCRIPTION
In the OutputConfigurationQuery the configuration source type id was called typeId and it creates a Configuration object where the same field is called sourceTypeId for the same field. When serializing the Configuration in the derived DataProviderDescriptor over TSP the field is called sourceTypeId and this is not consistent. The returned Configuration should have the exact field names that are used when creating the data provider and the respective configuration.

The Configuration is already API while OutputConfigurationQuery is not, and it's better to change the name there.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>