### PR TITLE
Add Bookmark endpoints specifications and update TSP version to 0.3.0

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -26,12 +26,14 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.2.0
+  version: 0.3.0
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
 - name: Annotations
   description: Retrieve annotations for different outputs.
+- name: Bookmarks
+  description: Bookmark areas of interest in the experiment.
 - name: Configurations
   description: Manage configuration source types and configurations.
 - name: Diagnostic
@@ -56,8 +58,6 @@ tags:
   description: Query virtual table models (e.g. Events Table).
 - name: XY
   description: Query XY chart models.
-- name: Bookmarks
-  description: How to bookmark areas of interest in the trace.
 - name: Filters
   description: How to filter and query.
 - name: Features
@@ -65,6 +65,185 @@ tags:
 - name: Symbols
   description: Learn how to provide symbol providers.
 paths:
+  /experiments/{expUUID}/bookmarks:
+    get:
+      tags:
+      - Bookmarks
+      summary: Get all bookmarks for an experiment
+      operationId: getBookmarks
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Returns the list of bookmarks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
+    post:
+      tags:
+      - Bookmarks
+      summary: Create a new bookmark in an experiment
+      operationId: createBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookmarkQueryParameters'
+        required: true
+      responses:
+        "200":
+          description: Bookmark created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "400":
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/bookmarks/{bookmarkUUID}:
+    get:
+      tags:
+      - Bookmarks
+      summary: Get a specific bookmark from an experiment
+      operationId: getBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Returns the bookmark
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
+    put:
+      tags:
+      - Bookmarks
+      summary: Update an existing bookmark in an experiment
+      operationId: updateBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookmarkQueryParameters'
+        required: true
+      responses:
+        "200":
+          description: Bookmark updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "400":
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
+    delete:
+      tags:
+      - Bookmarks
+      summary: Delete a bookmark from an experiment
+      operationId: deleteBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Bookmark deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
   /config/types/{typeId}/configs/{configId}:
     get:
       tags:
@@ -1946,174 +2125,6 @@ paths:
           description: Returns the Symbol providers for this query.
         404:
           description: No such Host, Thread and address combination.
-  /experiments/{expUUID}/bookmarks:
-    get:
-      summary: Get the collection of bookmarks for an experiment.
-      operationId: getExperimentBookmarks
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns a list of bookmarks for this trace
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such experiment
-          content:
-            application/json:
-              schema:
-                type: string
-    post:
-      summary: Add a bookmark to an experiment.
-      operationId: postExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        description: The bookmark to post
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Bookmark"
-      responses:
-        200:
-          description: Returns the bookmark's Id
-          content:
-            application/json:
-              schema:
-                type: integer
-        404:
-          description: No such trace
-          content:
-            application/json:
-              schema:
-                type: string
-  /experiments/{expUUID}/bookmarks/{bookmarkId}:
-    get:
-      summary: Get a specific bookmark from this experiment
-      operationId: getExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to get
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns the queried bookmark
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such experiment / No such bookmark
-          content:
-            application/json:
-              schema:
-                type: string
-    put:
-      summary: Modify a bookmark
-      operationId: putExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to modify
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: The bookmark to update
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Bookmark"
-      responses:
-        200:
-          description: Returns the bookmark's Id
-          content:
-            application/json:
-              schema:
-                type: integer
-        404:
-          description: No such trace
-          content:
-            application/json:
-              schema:
-                type: string
-    delete:
-      summary: Delete a bookmark
-      operationId: deleteExperimentBookmark
-      tags:
-        - Bookmarks
-      parameters:
-        - name: expUUID
-          in: path
-          description: The UUID of the experiment in the server
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: bookmarkId
-          in: path
-          description: The unique identifier of the bookmark to delete
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: Returns the deleted bookmark
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Bookmark"
-        404:
-          description: No such trace or bookmark
-          content:
-            application/json:
-              schema:
-                type: string
   /experiments/{expUUID}/outputs/data/{outputID}/tree:
     post:
       tags:
@@ -2317,6 +2328,50 @@ paths:
                           $ref: "#/components/schemas/TimeGraphModel"
 components:
   schemas:
+    Bookmark:
+      type: object
+      properties:
+        name:
+          type: string
+          description: User defined name for the bookmark
+        end:
+          type: integer
+          description: The bookmark's end time
+          format: int64
+        start:
+          type: integer
+          description: The bookmark's start time
+          format: int64
+        uuid:
+          type: string
+          description: The bookmark's unique identifier
+          format: uuid
+    BookmarkParameters:
+      required:
+      - end
+      - name
+      - start
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name to give this bookmark
+        end:
+          type: integer
+          description: The bookmark's end time
+          format: int64
+        start:
+          type: integer
+          description: The bookmark's start time
+          format: int64
+      description: The bookmark parameters
+    BookmarkQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/BookmarkParameters'
     Configuration:
       type: object
       properties:
@@ -3373,30 +3428,6 @@ components:
         uri:
           type: string
           description: URI of the trace
-    Bookmark:
-      type: object
-      properties:
-        start:
-          description: the start time for this bookmark.
-          type: integer
-          format: int64
-        end:
-          description: the end time for this bookmark.
-          type: integer
-          format: int64
-        name:
-          description: this bookmark's name
-          type: string
-        type:
-          description: The type of the bookmark (generic, output, ...)
-          type: string
-        iconUrl:
-          description: URL to the bookmark's icon
-          type: string
-        UUID:
-          description: The bookmark's unique ID, generated by the server.
-          type: string
-          format: uuid
     Filter:
       type: object
       properties:

--- a/API.yaml
+++ b/API.yaml
@@ -26,12 +26,14 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.2.0
+  version: 0.3.0
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
 - name: Annotations
   description: Retrieve annotations for different outputs.
+- name: Bookmarks
+  description: Bookmark areas of interest in the experiment.
 - name: Configurations
   description: Manage configuration source types and configurations.
 - name: Diagnostic
@@ -57,6 +59,185 @@ tags:
 - name: XY
   description: Query XY chart models.
 paths:
+  /experiments/{expUUID}/bookmarks:
+    get:
+      tags:
+      - Bookmarks
+      summary: Get all bookmarks for an experiment
+      operationId: getBookmarks
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Returns the list of bookmarks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
+    post:
+      tags:
+      - Bookmarks
+      summary: Create a new bookmark in an experiment
+      operationId: createBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookmarkQueryParameters'
+        required: true
+      responses:
+        "200":
+          description: Bookmark created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "400":
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/bookmarks/{bookmarkUUID}:
+    get:
+      tags:
+      - Bookmarks
+      summary: Get a specific bookmark from an experiment
+      operationId: getBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Returns the bookmark
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
+    put:
+      tags:
+      - Bookmarks
+      summary: Update an existing bookmark in an experiment
+      operationId: updateBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookmarkQueryParameters'
+        required: true
+      responses:
+        "200":
+          description: Bookmark updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "400":
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
+    delete:
+      tags:
+      - Bookmarks
+      summary: Delete a bookmark from an experiment
+      operationId: deleteBookmark
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: bookmarkUUID
+        in: path
+        description: Bookmark UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Bookmark deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
+        "404":
+          description: Experiment or bookmark not found
+          content:
+            application/json:
+              schema:
+                type: string
   /config/types/{typeId}/configs/{configId}:
     get:
       tags:
@@ -1626,6 +1807,50 @@ paths:
                 type: string
 components:
   schemas:
+    Bookmark:
+      type: object
+      properties:
+        name:
+          type: string
+          description: User defined name for the bookmark
+        end:
+          type: integer
+          description: The bookmark's end time
+          format: int64
+        start:
+          type: integer
+          description: The bookmark's start time
+          format: int64
+        uuid:
+          type: string
+          description: The bookmark's unique identifier
+          format: uuid
+    BookmarkParameters:
+      required:
+      - end
+      - name
+      - start
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name to give this bookmark
+        end:
+          type: integer
+          description: The bookmark's end time
+          format: int64
+        start:
+          type: integer
+          description: The bookmark's start time
+          format: int64
+      description: The bookmark parameters
+    BookmarkQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/BookmarkParameters'
     Configuration:
       type: object
       properties:


### PR DESCRIPTION
The specifications of newly introduced endpoints for managing bookmarks of experiments are added to the API.yaml and API-proposed.yaml. Also, TSP version is udpated to 0.3.0 from 0.2.0.