### PR TITLE
Dp capabilities

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2496,6 +2496,21 @@ components:
           - NONE
         configuration:
           $ref: '#/components/schemas/Configuration'
+        capabilities:
+          $ref: '#/components/schemas/OutputCapabilities'
+    OutputCapabilities:
+      type: object
+      properties:
+        canDelete:
+          type: boolean
+          description: "Optional, whether this output (data provider) can be deleted.\
+            \ 'false' if absent."
+        canCreate:
+          type: boolean
+          description: "Optional, whether this output (data provider) can create derived\
+            \ outputs (data providers). 'false' if absent."
+      description: "Optional output capabilities, such as 'canCreate' and 'canDelete'.\
+        \ If absent, all capabilities are 'false'."
     OutputConfigurationQueryParameters:
       required:
       - typeId

--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2513,7 +2513,7 @@ components:
         \ If absent, all capabilities are 'false'."
     OutputConfigurationQueryParameters:
       required:
-      - typeId
+      - sourceTypeId
       type: object
       allOf:
       - $ref: '#/components/schemas/ConfigurationQueryParameters'
@@ -2521,8 +2521,8 @@ components:
         properties:
           sourceTypeId:
             type: string
-            description: The type ID of the corresponding ConfigurationSourceType defined by this output.
-              ConfigurationTypeDescriptor.
+            description: The type ID of the corresponding ConfigurationSourceType
+              defined by this output.
     AnnotationCategoriesModel:
       type: object
       properties:

--- a/API.yaml
+++ b/API.yaml
@@ -1975,6 +1975,21 @@ components:
           - NONE
         configuration:
           $ref: '#/components/schemas/Configuration'
+        capabilities:
+          $ref: '#/components/schemas/OutputCapabilities'
+    OutputCapabilities:
+      type: object
+      properties:
+        canDelete:
+          type: boolean
+          description: "Optional, whether this output (data provider) can be deleted.\
+            \ 'false' if absent."
+        canCreate:
+          type: boolean
+          description: "Optional, whether this output (data provider) can create derived\
+            \ outputs (data providers). 'false' if absent."
+      description: "Optional output capabilities, such as 'canCreate' and 'canDelete'.\
+        \ If absent, all capabilities are 'false'."
     OutputConfigurationQueryParameters:
       required:
       - typeId

--- a/API.yaml
+++ b/API.yaml
@@ -1992,7 +1992,7 @@ components:
         \ If absent, all capabilities are 'false'."
     OutputConfigurationQueryParameters:
       required:
-      - typeId
+      - sourceTypeId
       type: object
       allOf:
       - $ref: '#/components/schemas/ConfigurationQueryParameters'
@@ -2000,8 +2000,8 @@ components:
         properties:
           sourceTypeId:
             type: string
-            description: The type ID of the corresponding ConfigurationSourceType defined by this output.
-              ConfigurationTypeDescriptor.
+            description: The type ID of the corresponding ConfigurationSourceType
+              defined by this output.
     AnnotationCategoriesModel:
       type: object
       properties:


### PR DESCRIPTION
### What it does

This PR adds the `DataProviderCapabilities` API to the swagger documentation. A second commit fixes the `OutputConfigurationQueryParameters` documentation by changing the field name `typeId` to `sourceTypeId`, and by updating the corresponding description.

### How to test

Open API.yaml and API-proposed.yaml in your favourite swagger editor.

See also ADR: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>