### PR TITLE
Document meaning of value -1 for parentId of TreeDataModel

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2803,14 +2803,14 @@ components:
           description: Whether or not this entry has data
         parentId:
           type: integer
-          description: "Unique id to identify this parent's entry, optional if this\
-            \ entry does not have a parent."
+          description: "Optional unique ID to identify this entry's parent. If the\
+            \ parent ID is -1 or omitted, this entry has no parent."
           format: int64
         style:
           $ref: '#/components/schemas/OutputElementStyle'
         id:
           type: integer
-          description: Unique id to identify this entry in the backend
+          description: Unique ID to identify this entry in the backend
           format: int64
         labels:
           type: array

--- a/API.yaml
+++ b/API.yaml
@@ -2282,14 +2282,14 @@ components:
           description: Whether or not this entry has data
         parentId:
           type: integer
-          description: "Unique id to identify this parent's entry, optional if this\
-            \ entry does not have a parent."
+          description: "Optional unique ID to identify this entry's parent. If the\
+            \ parent ID is -1 or omitted, this entry has no parent."
           format: int64
         style:
           $ref: '#/components/schemas/OutputElementStyle'
         id:
           type: integer
-          description: Unique id to identify this entry in the backend
+          description: Unique ID to identify this entry in the backend
           format: int64
         labels:
           type: array


### PR DESCRIPTION
### What it does

Document meaning of value -1 for parentId of TreeDataModel.

Fixes #65

Corresponding swagger model update:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/191

### How to test

Open API.yaml and API-proposed.yaml in your favourite swagger editor and verify the change is applied.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>