### PR TITLE
Allow double and remove boolean in OutputElementStyle

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2635,10 +2635,9 @@ components:
       oneOf:
       - type: string
       - type: number
-        format: float
+        format: double
       - type: integer
         format: int32
-      - type: boolean
     AnnotationsParameters:
       required:
       - requested_timerange

--- a/API.yaml
+++ b/API.yaml
@@ -2114,10 +2114,9 @@ components:
       oneOf:
       - type: string
       - type: number
-        format: float
+        format: double
       - type: integer
         format: int32
-      - type: boolean
     AnnotationsParameters:
       required:
       - requested_timerange


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/trace-server-protocol/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Previously only float values were allowed. Don't restrict to float and allow Double as well. Note when deserializing JSON strings a floating point value will be deserialized to Double, e.g. when using Jackson deserializer (Java) or in Javascript.

Remove boolean because it can be expressed as String and boolean have no equivalent type in CSS where the StyleProperties are inspired of.

Contributes to #102

Corresponding swagger model update:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/192

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open API.yaml and API-proposed.yaml in your favourite swagger editor and verify the change is applied.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
