### PR TITLE
Fix configuration parameters - part 2

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -2419,10 +2419,7 @@ components:
           description: The unique ID of the configuration instance
         parameters:
           type: object
-          additionalProperties:
-            type: object
-            description: Optional parameters representing the configuration parameters
-              used to create this configuration.
+          additionalProperties: true
           description: Optional parameters representing the configuration parameters
             used to create this configuration.
       description: Configuration instance describing user provided configuration parameters.

--- a/API.yaml
+++ b/API.yaml
@@ -1898,10 +1898,7 @@ components:
           description: The unique ID of the configuration instance
         parameters:
           type: object
-          additionalProperties:
-            type: object
-            description: Optional parameters representing the configuration parameters
-              used to create this configuration.
+          additionalProperties: true
           description: Optional parameters representing the configuration parameters
             used to create this configuration.
       description: Configuration instance describing user provided configuration parameters.


### PR DESCRIPTION
### What it does

Fix parameters field specification of Configuration. Now the parameters field is a free-from dictionary as originally intended.
fixes https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/123

The changes were generated using commits of PR https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/219 for the Trace Server.

Fixes #130

### How to test

Open specification in swagger editor and verify that changes are correct

### Follow-ups

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
