### PR TITLE
Return DataTreeResponse instead of XYTreeResponse

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -994,7 +994,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/XYTreeResponse"
+                $ref: "#/components/schemas/DataTreeResponse"
         "400":
           description: Invalid query parameters
           content:
@@ -2924,6 +2924,30 @@ components:
       properties:
         parameters:
           $ref: "#/components/schemas/OptionalParameters"
+    DataTreeEntry:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/TreeDataModel"
+    DataTreeEntryModel:
+      required:
+      - entries
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/TreeEntryModel"
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: "#/components/schemas/DataTreeEntry"
+    DataTreeResponse:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/GenericResponse"
+      - type: object
+        properties:
+          model:
+            $ref: "#/components/schemas/DataTreeEntryModel"
     TreeColumnHeader:
       required:
       - name

--- a/API.yaml
+++ b/API.yaml
@@ -988,7 +988,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/XYTreeResponse"
+                $ref: "#/components/schemas/DataTreeResponse"
         "400":
           description: Invalid query parameters
           content:
@@ -2403,6 +2403,30 @@ components:
       properties:
         parameters:
           $ref: "#/components/schemas/OptionalParameters"
+    DataTreeEntry:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/TreeDataModel"
+    DataTreeEntryModel:
+      required:
+      - entries
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/TreeEntryModel"
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: "#/components/schemas/DataTreeEntry"
+    DataTreeResponse:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/GenericResponse"
+      - type: object
+        properties:
+          model:
+            $ref: "#/components/schemas/DataTreeEntryModel"
     TreeColumnHeader:
       required:
       - name


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/trace-server-protocol/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Return DataTreeResponse instead of XYTreeResponse

The endpoint to fetch data tree swagger definition returned the XYTreeResponse and related data structures. This commit corrects the swagger definition for that.

Fixes #128

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open updated yaml files and verify the changes.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
